### PR TITLE
option to disable paging

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -126,5 +126,8 @@ num_lines <- function() {
 }
 
 should_page <- function(src) {
-  is_interactive() && is_terminal() && length(src) > num_lines()
+  is_interactive() &&
+  is_terminal() &&
+  getOption("prettycode.should_page", TRUE) &&
+  (length(src) > num_lines())
 }

--- a/inst/README.markdown
+++ b/inst/README.markdown
@@ -25,6 +25,10 @@ screen. Long functions are automatically paged using the default pager.
 
 ![](/inst/screenshot.png)
 
+### Options
+
+  - `prettycode.should_page` controls paging. Use `FALSE` to disable paging for long functions.
+
 ## License
 
 MIT © Gábor Csárdi


### PR DESCRIPTION
Thanks for the handy tool!

I already have keyboard shortcuts for scrolling my R terminal so the paging kind of trips me up.

Here's an option to disable it.