### PR TITLE
Fix handling of long strings and symbols in highlight()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 # pretttycode development version
 
 * Printing primitive functions excludes their `NULL` environment (#11 @mdequeljoe)
+* `highlight()` supports long strings and symbols (#21 @moodymudskipper)
 
 # prettycode 1.1.0
 

--- a/tests/testthat/test-highlight.R
+++ b/tests/testthat/test-highlight.R
@@ -110,3 +110,19 @@ test_that("bracket", {
     "foo <- functionBxBBxB"
   )
 })
+
+test_that("long strings and symbols", {
+  expect_true(
+    grepl(
+      strrep("-", 1000),
+      highlight(paste0("foo('", strrep("-", 1000), "')"))
+    )
+  )
+
+  expect_true(
+    grepl(
+      strrep("-", 1000),
+      highlight(paste0("foo(`", strrep("-", 1000), "`)"))
+    )
+  )
+})


### PR DESCRIPTION
Closes #20

We implement `get_parse_data()` as an alternative to `getParseDate(, includeText = NA)`

for strings and symbols we consider the text from the parent if : 

* the string or symbol starts with "["
* the parent is an expr (not sure if necessary after testing for above, to be safe)
* the parent has a single child (to dismiss some corner cases)

New behaviour:

``` r
x <- paste0("fun('", strrep("-", 1000), "')")
prettycode::highlight(x)
#> [1] "fun('----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------')"
```

<sup>Created on 2022-11-10 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

There are still corner cases unfortunately, see below in the parse data how the expression combines children so cannot be used as is.

I didn't go through the rabbit hole for those, they're unlikely to be encountered in practice. we keep the previous behavior.

``` r
code <- sprintf("b$'%s'", strrep("a", 1000))
pd <- getParseData(parse(text=code), includeText = TRUE)
pd$text <- substr(pd$text,1, 30)
pd
#>   line1 col1 line2 col2 id parent     token terminal
#> 5     1    1     1 1004  5      0      expr    FALSE
#> 1     1    1     1    1  1      3    SYMBOL     TRUE
#> 3     1    1     1    1  3      5      expr    FALSE
#> 2     1    2     1    2  2      5       '$'     TRUE
#> 4     1    3     1 1004  4      5 STR_CONST     TRUE
#>                             text
#> 5 b$'aaaaaaaaaaaaaaaaaaaaaaaaaaa
#> 1                              b
#> 3                              b
#> 2                              $
#> 4   [1000 chars quoted with ''']
prettycode::highlight(code)
#> [1] "b$[1000 chars quoted with ''']"
```

<sup>Created on 2022-11-10 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup> 

