### PR TITLE
Added highlighting for additional equal signs and package names

### DIFF
--- a/R/highlight.R
+++ b/R/highlight.R
@@ -23,7 +23,9 @@ operator_tokens <- function() {
     "RIGHT_ASSIGN",
     "'$'",
     "'@'",
-    "EQ_ASSIGN"
+    "EQ_ASSIGN",
+    "EQ_SUB",
+    "EQ_FORMALS"
   )
 }
 
@@ -101,6 +103,12 @@ highlight <- function(code, style = default_style()) {
   if (!is.null(style$call)) {
     fun_call <- data$token == "SYMBOL_FUNCTION_CALL"
     hitext[fun_call] <- style$call(data$text[fun_call])
+  }
+
+  ## Package names - use operator styling directly
+  if (!is.null(style$operator)) {
+    package <- data$token == "SYMBOL_PACKAGE"
+    hitext[package] <- style$operator(data$text[package])
   }
 
   ## Strings

--- a/tests/testthat/test-highlight.R
+++ b/tests/testthat/test-highlight.R
@@ -78,10 +78,33 @@ test_that("operator", {
     ),
     "a OP 10; 20 OP b; c OP 30; aOPb; aOPb"
   )
+
+  expect_equal(
+    highlight(
+      "func(arg = value)",
+      list(operator = function(x) "OP")
+    ),
+    "func(arg OP value)"
+  )
+
+  expect_equal(
+    highlight(
+      "function(x = 5) x",
+      list(operator = function(x) "OP")
+    ),
+    "function(x OP 5) x"
+  )
 })
 
 test_that("call", {
   expect_equal(highlight("ls(2)", list(call = function(x) "F")), "F(2)")
+})
+
+test_that("package", {
+  expect_equal(
+    highlight("base::print()", list(operator = function(x) "OP")),
+    "OP::print()"
+  )
 })
 
 test_that("string", {


### PR DESCRIPTION
Hi Gabor. I started working on this for Tidy Dev Day. I am happy to take any guidance or feedback you offer.

Changes:
Added highlighting for package names and additional equal sign operator tokens. I could not get the package name tokens to highlight in light purple as the Twilight theme does in the editor, so I set package names to take on the same color as operators.  This addresses issue #15.

Note:
This solution was suggested by Claude Code ✨. I tested many versions in the RStudio R console and terminal, and the highlights work in both, though the terminal still uses its own color for operators (green) versus what the Twilight theme can produce in the console (light purple). I am not sure if this meets user expectations.